### PR TITLE
Minor fix for anet_entities_skeleton.txt

### DIFF
--- a/data/anet_entities_skeleton.txt
+++ b/data/anet_entities_skeleton.txt
@@ -20,7 +20,7 @@ Format of JSON ActivityNet-Entities annotation files
 
 ### for anet_entities_cleaned_class_thresh50_trainval.json
 -> vocab: the 431 object classes (not including the background class)
--> database
+-> annotations
   -> [video name]: identifier of video
     -> segments
       -> [segment id]: segment from video with bounding box annotations


### PR DESCRIPTION
I downloaded 

```
with open("./anet_entities_cleaned_class_thresh50_trainval.json") as f:
  clean = json.load(f)

print(clean.keys())
```

It prints "[u'annotations', u'vocab']"